### PR TITLE
fix: JqCallLoop can be called from go routine, not from "main" thread

### DIFF
--- a/pkg/jq/call_loop.go
+++ b/pkg/jq/call_loop.go
@@ -6,12 +6,9 @@ import "runtime"
 libjq methods should run from main thread, so this trick with LockOsThread come up.
 */
 
-func init() {
-	runtime.LockOSThread()
-}
-
 // JqCallLoop handles external functions. This loop should be started from the main.main.
 func JqCallLoop(done chan struct{}) {
+	runtime.LockOSThread()
 	for {
 		select {
 		case f := <-jqcalls:

--- a/pkg/jq/jq_test.go
+++ b/pkg/jq/jq_test.go
@@ -3,6 +3,7 @@ package jq
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -85,12 +86,15 @@ func Test_Concurent_FieldAccess(t *testing.T) {
 		}
 	}
 
-	parallelism := 16
+	parallelism := 32
 
 	var wg sync.WaitGroup
 	wg.Add(parallelism)
 	for i := 0; i < parallelism; i++ {
 		go func() {
+			if parallelism%2 == 0 {
+				runtime.LockOSThread()
+			}
 			job()
 			wg.Done()
 		}()


### PR DESCRIPTION
- no need to block the main method