### PR TITLE
scripts: fix 'git submodule' command line

### DIFF
--- a/scripts/build-libjq-static.sh
+++ b/scripts/build-libjq-static.sh
@@ -9,7 +9,7 @@ echo "Build jq library into '${out}'"
 
 cd ${root}/modules/jq
 
-git submodules update --init
+git submodule update --init
 
 autoreconf -fi
 ./configure CFLAGS=-fPIC --disable-maintainer-mode \


### PR DESCRIPTION
The right command is 'git submodule', not 'git submodules'