### PR TITLE
feat: catch compile errors

### DIFF
--- a/jq_test.go
+++ b/jq_test.go
@@ -47,3 +47,22 @@ func Benchmark_PreCompile(b *testing.B) {
 		}
 	}
 }
+
+func Test_CompileError(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := Jq().Program(`{"message": .message"}`).Run(`{"message":"bar"}`)
+
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("jq: error: syntax error"))
+	g.Expect(err.Error()).To(ContainSubstring("compile error"))
+	g.Expect(err.Error()).ToNot(ContainSubstring("0 0 0")) // {0 0 0 0 [0 0 0 0 0 0 0 0]}
+}
+
+func Test_RunError(t *testing.T) {
+	g := NewWithT(t)
+	_, err := Jq().Program(".foo[] | keys").Run(`{"foo":"bar"}`)
+
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("Cannot iterate over string"))
+}

--- a/pkg/libjq/jv.go
+++ b/pkg/libjq/jv.go
@@ -31,3 +31,14 @@ func JvArray(first C.jv, items ...C.jv) C.jv {
 	}
 	return arr
 }
+
+func JvArrayToGo(a C.jv) []string {
+	var l C.int = C.jv_array_length(C.jv_copy(a))
+	res := make([]string, l)
+	for i := C.int(0); i < l; i++ {
+		var item C.jv = C.jv_array_get(C.jv_copy(a), i)
+		res[i] = C.GoString(C.jv_string_value(item))
+		C.jv_free(item)
+	}
+	return res
+}


### PR DESCRIPTION
`jq_compile` prints errors to the `stderr` by default:

```
jq: error: syntax error, unexpected QQSTRING_START, expecting '}' (Unix shell quoting issues?) at <top-level>, line 3:
  "message": .message",                     
jq: 1 compile error
```

This behavior interferes with logging, especially when JSON logging is turned on. Given PR implements a callback that catches errors into jv_array. Now compile errors can be returned as a usual error.